### PR TITLE
PI-744 Script to re-organise secrets

### DIFF
--- a/secrets/delete-github-secrets.sh
+++ b/secrets/delete-github-secrets.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+projects='APPROVED_PREMISES_AND_DELIUS APPROVED_PREMISES_AND_OASYS CUSTODY_KEY_DATES_AND_DELIUS MAKE_RECALL_DECISIONS_AND_DELIUS MANAGE_POM_CASES_AND_DELIUS OFFENDER_EVENTS_AND_DELIUS PERSON_SEARCH_INDEX_FROM_DELIUS PRE_SENTENCE_REPORTS_TO_DELIUS PRISON_CASE_NOTES_TO_PROBATION PRISON_CUSTODY_STATUS_TO_DELIUS REFER_AND_MONITOR_AND_DELIUS RISK_ASSESSMENT_SCORES_TO_DELIUS TIER_TO_DELIUS UNPAID_WORK_AND_DELIUS WORKFORCE_ALLOCATIONS_TO_DELIUS'
+envs='test preprod prod'
+
+cd ~/IdeaProjects/hmpps-probation-integration-services || exit 1
+for project in $projects; do
+  gh secret list | grep "$project" | awk '{print $1}' | xargs -n1 gh secret delete
+  for env in $envs; do
+    gh secret list --env "$env" | grep "$project" | awk '{print $1}' | xargs -n1 gh secret delete --env "$env"
+  done
+done

--- a/secrets/reorganise-secrets.sh
+++ b/secrets/reorganise-secrets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Usage: eval "$(./reorganise-secrets.sh)"
+
+projects='approved-premises-and-delius approved-premises-and-oasys custody-key-dates-and-delius make-recall-decisions-and-delius manage-pom-cases-and-delius offender-events-and-delius person-search-index-from-delius pre-sentence-reports-to-delius prison-case-notes-to-probation prison-custody-status-to-delius refer-and-monitor-and-delius risk-assessment-scores-to-delius tier-to-delius unpaid-work-and-delius workforce-allocations-to-delius'
+namespaces='hmpps-probation-integration-services-dev hmpps-probation-integration-services-preprod hmpps-probation-integration-services-prod'
+
+function reorganise_secret() {
+  local namespace=$1
+  local project=$2
+  local yml_file="$namespace/$project.yml"
+  local new_secret_suffix=$3
+  shift 3
+
+  local command="kubectl -n '$namespace' create secret generic '$project-$new_secret_suffix'"
+  local create_secret=false
+  for key in "$@"; do
+    # if the value already exists in the old secret
+    if [ "$(yq '.data | has("'"$key"'")' "$yml_file")" == 'true' ]; then
+      create_secret=true
+      # then create it in the new structure
+      command="$command --from-literal='$key=$(yq ".data.$key" "$yml_file" | base64 -d)'"
+    fi
+  done
+  if [ "$create_secret" = 'true' ]; then echo "$command"; fi
+}
+
+for namespace in $namespaces; do
+  mkdir -p "$namespace"
+  for project in $projects; do
+    kubectl -n "$namespace" get secret "$project" -o yaml > "$namespace/$project.yml"
+    reorganise_secret "$namespace" "$project" 'client-credentials' 'CLIENT_ID' 'CLIENT_SECRET' 'ORDS_CLIENT_ID' 'ORDS_CLIENT_SECRET'
+    reorganise_secret "$namespace" "$project" 'database' 'DB_USERNAME' 'DB_PASSWORD'
+    reorganise_secret "$namespace" "$project" 'sentry' 'SENTRY_DSN'
+  done
+done

--- a/secrets/reorganise-secrets.sh
+++ b/secrets/reorganise-secrets.sh
@@ -3,7 +3,7 @@
 # Usage: eval "$(./reorganise-secrets.sh)"
 
 projects='approved-premises-and-delius approved-premises-and-oasys custody-key-dates-and-delius make-recall-decisions-and-delius manage-pom-cases-and-delius offender-events-and-delius person-search-index-from-delius pre-sentence-reports-to-delius prison-case-notes-to-probation prison-custody-status-to-delius refer-and-monitor-and-delius risk-assessment-scores-to-delius tier-to-delius unpaid-work-and-delius workforce-allocations-to-delius'
-namespaces='hmpps-probation-integration-services-dev hmpps-probation-integration-services-preprod hmpps-probation-integration-services-prod'
+namespaces='hmpps-probation-integration-services-prod'
 
 function reorganise_secret() {
   local namespace=$1


### PR DESCRIPTION
This script re-organises secrets from the flat structure we have at the moment (due to them being synced from GitHub), into separate secrets for different sets of credentials. E.g. instead of all values being in a single `approved-premises-and-delius` secret, they'll be separated into `approved-premises-and-delius-database`, `approved-premises-and-delius-queue`, `approved-premises-and-delius-client-credentials` etc.

This enables each secret to be individually managed - so the queue/topic secrets can be managed by Terraform, the OAuth credentials can be managed by the auth team, etc.