### PR TITLE
PI-1079 Scripts to fix contact outcomes for R&M

### DIFF
--- a/refer-and-monitor/get-sentry-events.sh
+++ b/refer-and-monitor/get-sentry-events.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+##
+## Get all pages of Sentry events for an issue
+##
+## Usage:
+##   SENTRY_API_KEY=... ISSUE_ID=... ./get-sentry-events.sh
+##
+set -eo pipefail
+source ../common.sh
+
+if [ -z "$SENTRY_API_KEY" ]; then print_usage; fail "SENTRY_API_KEY not set"; fi
+if [ -z "$ISSUE_ID" ]; then print_usage; fail "ISSUE_ID not set"; fi
+
+sentry_events='[]'
+cursor=0
+while [ "$page" != '[]' ]; do
+  page=$(curl -H "Authorization: Bearer $SENTRY_API_KEY" "https://sentry.io/api/0/issues/$ISSUE_ID/events/?full=true&cursor=0:$cursor:0")
+  sentry_events=$(printf '%s\n%s' "$sentry_events" "$page" | jq -s 'add')
+  cursor=$((cursor + 100))
+done
+
+echo "$sentry_events"

--- a/refer-and-monitor/get-sentry-events.sh
+++ b/refer-and-monitor/get-sentry-events.sh
@@ -14,9 +14,9 @@ if [ -z "$ISSUE_ID" ]; then print_usage; fail "ISSUE_ID not set"; fi
 sentry_events='[]'
 cursor=0
 while [ "$page" != '[]' ]; do
-  page=$(curl -H "Authorization: Bearer $SENTRY_API_KEY" "https://sentry.io/api/0/issues/$ISSUE_ID/events/?full=true&cursor=0:$cursor:0")
-  sentry_events=$(printf '%s\n%s' "$sentry_events" "$page" | jq -s 'add')
+  page=$(curl --retry 5 --fail -H "Authorization: Bearer $SENTRY_API_KEY" "https://sentry.io/api/0/issues/$ISSUE_ID/events/?full=true&cursor=0:$cursor:0")
+  sentry_events=$(printf '%s\n%s' "$sentry_events" "$page")
   cursor=$((cursor + 100))
 done
 
-echo "$sentry_events"
+echo "$sentry_events" | jq -s 'add'

--- a/refer-and-monitor/recreate-messages.sh
+++ b/refer-and-monitor/recreate-messages.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+##
+## Output SNS messages for correcting Contact outcomes in Delius based on Sentry events
+##
+## Usage:
+##   SENTRY_API_KEY=... ISSUE_ID=... \
+##   ./get-sentry-events.sh | ./reconstruct-messages.sh | python3 ../sqs-utils.py send "$SQS_QUEUE_URL" | tee send-output.log
+##
+set -eo pipefail
+source ../common.sh
+
+cat "${1:-/dev/stdin}" \
+| jq '.[].context."async-event"' \
+| sed -E 's/"ActionPlanAppointmentEvent\(type=(.+?), deliverySessionId=(.+?), detailUrl='"'"'(.+?\/referral\/([^\/]+?)\/sessions\/([^\/]+?).+?)'"'"', source=(.+?)\)"/\4 \5 \3/' \
+| while read -r referralId sessionNumber detailUrl; do
+  auth="$(echo -n $(kubectl -n hmpps-probation-integration-services-prod get secret refer-and-monitor-and-delius-client-credentials -o yaml | yq '.data.CLIENT_ID' | base64 -d):$(kubectl -n hmpps-probation-integration-services-prod get secret refer-and-monitor-and-delius-client-credentials -o yaml | yq '.data.CLIENT_SECRET' | base64 -d) | base64 -w0)"
+  HMPPS_AUTH_TOKEN=$(kubectl -n hmpps-probation-integration-services-prod exec deployment/refer-and-monitor-and-delius -- sh -c "wget --header 'Authorization: Basic $auth' --post-data '' -O - 'https://sign-in.hmpps.service.justice.gov.uk/auth/oauth/token?grant_type=client_credentials' 2>/dev/null" | jq -r '.access_token' | tr -d '\n')
+  export HMPPS_AUTH_TOKEN
+  session=$(kubectl -n hmpps-probation-integration-services-prod exec deployment/person-search-index-from-delius -- curl --silent --fail --retry 3 --output - -H "Authorization: Bearer $HMPPS_AUTH_TOKEN" "https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk/referral/$referralId/sessions/$sessionNumber" \
+            | jq '. | {
+              deliusAppointmentId: .deliusAppointmentId,
+              referralProbationUserURL: ("https://refer-monitor-intervention.service.justice.gov.uk/probation-practitioner/referrals/'"$referralId"'/session/'"$sessionNumber"'/appointment/" + ((.deliusAppointmentId // "0")|tostring) + "/post-session-feedback")
+            }')
+  referral=$(kubectl -n hmpps-probation-integration-services-prod exec deployment/person-search-index-from-delius -- curl --silent --fail --retry 3 --output - -H "Authorization: Bearer $HMPPS_AUTH_TOKEN" "https://hmpps-interventions-service.apps.live-1.cloud-platform.service.justice.gov.uk/sent-referral/$referralId" \
+             | jq '. | {
+               referralId: .id,
+               referralReference: .referenceNumber,
+               contractTypeName: .referral.contractTypeName,
+               primeProviderName: .referral.serviceProvider.name,
+               crn: .referral.serviceUser.crn
+             }')
+  echo -e "$session\n$referral" | jq -s '.[0] * .[1]' | jq '{
+    "eventType": "intervention.session-appointment.session-feedback-submitted",
+    "version": 1,
+    "description": "Session feedback submitted for a session appointment",
+    "detailUrl": "'"$detailUrl"'",
+    "occurredAt": "'"$(TZ=UTC date '+%Y-%m-%dT%H:%M:%S.%3NZ')"'",
+    "personReference": {
+      "identifiers": [{"type": "CRN", "value": .crn}]
+    },
+    "additionalInformation": .
+  }' | \
+  jq -c '{
+    "Type": "Notification",
+    "MessageId": "00000000-0000-0000-0000-000000000000",
+    "TopicArn": "arn:aws:sns:eu-west-2:754256621582:cloud-platform-Digital-Prison-Services-e29fb030a51b3576dd645aa5e460e573",
+    "Message": . | tojson,
+    "Timestamp": .occurredAt,
+    "MessageAttributes": {
+      "eventType": {"Type": "String", "Value": .eventType}
+    }
+  }'
+done

--- a/refer-and-monitor/repopulate-outcomes.sh
+++ b/refer-and-monitor/repopulate-outcomes.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+##
+## Output SQL for correcting Contact outcomes in Delius based on Sentry events
+##
+## Usage:
+##   SENTRY_API_KEY=... ISSUE_ID=... ./get-sentry-events.sh | ./repopulate-outcomes.sh > output.sql
+##
+set -eo pipefail
+source ../common.sh
+
+cat "${1:-/dev/stdin}" \
+| jq '.[].entries[] | select(.type == "message") | .data.params[1]' \
+| sed -E 's/"req.body=AppointmentOutcomeRequest\(notes=(.+?https:\/\/refer-monitor-intervention.service.justice.gov.uk\/probation-practitioner\/referrals\/(.+?)\/supplier-assessment\/post-assessment.+?), attended=(.+?), notifyPPOfAttendanceBehaviour=(.+?)\)"/\
+update contact\
+set contact_outcome_type_id = (select contact_outcome_type_id from r_contact_outcome_type where code = '"'"'\3-\4'"'"'),\
+    notes = notes || chr(10) || chr(10) || '"'"'\1'"'"',\
+    last_updated_datetime = current_date,\
+    last_updated_user_id = 4\
+where nsi_id = (select nsi_id from nsi where external_reference='"'"'urn:hmpps:interventions-referral:\2'"'"')\
+and contact_outcome_type_id is null;/' \
+| sed "s/'YES-true'/'ATTC'/; s/'YES-false'/'AFTC'/; s/'NO-.*'/'AFTA'/" \
+| sed "s/\\n/' || chr(10) || '/"


### PR DESCRIPTION
## Setting outcomes via SQL
Example usage:
```bash
SENTRY_API_KEY=... ISSUE_ID=4170074036 ./get-sentry-events.sh | ./repopulate-outcomes.sh > output.sql
```

Example SQL output:
```sql
update contact
set contact_outcome_type_id = (select contact_outcome_type_id from r_contact_outcome_type where code = 'AFTC'),
    notes = notes || chr(10) || chr(10) || 'Session Feedback Recorded for Dependency and Recovery (South Yorkshire) Referral 12345678 with Prime Provider Change Grow Live (CGL) Services Ltd\nhttps://refer-monitor-intervention.service.justice.gov.uk/probation-practitioner/referrals/6d9c8132-9b20-4771-8291-94595409b146/supplier-assessment/post-assessment-feedback',
    last_updated_datetime = current_date,
    last_updated_user_id = 4
where nsi_id = (select nsi_id from nsi where external_reference='urn:hmpps:interventions-referral:6d9c8132-9b20-4771-8291-94595409b146')
and contact_outcome_type_id is null;

...
```


## Setting outcomes via SQS
```shell
SENTRY_API_KEY=... ISSUE_ID=4169994874 ./get-sentry-events.sh | ./reconstruct-messages.sh | python3 ../sqs-utils.py send "$SQS_QUEUE_URL" | tee send-output.log
```